### PR TITLE
Release version 0.1.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
  
 setup(
     name='django-oembed',
-    version='0.1.4ctl',
+    version='0.1.5',
     description='A collection of Django tools which make it easy to change text filled with oembed links into the embedded objects themselves.',
     author='Eric Florenzano',
     author_email='floguy@gmail.com',


### PR DESCRIPTION
No code changes here - newer pip doesn't allow version numbers like "0.1.4ctl".